### PR TITLE
Added styleable properties for Grid & replaced grid lines with Canvas.

### DIFF
--- a/api/src/main/java/de/tesis/dynaware/grapheditor/utils/GraphEditorProperties.java
+++ b/api/src/main/java/de/tesis/dynaware/grapheditor/utils/GraphEditorProperties.java
@@ -13,6 +13,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 
 /**
  * General properties for the graph editor.
@@ -37,7 +38,8 @@ public class GraphEditorProperties {
     public static final double DEFAULT_MAX_HEIGHT = Double.MAX_VALUE;
 
     private static final double DEFAULT_BOUND_VALUE = 15;
-    private static final double DEFAULT_GRID_SPACING = 10;
+    public static final double DEFAULT_GRID_SPACING = 10;
+    public static final Paint DEFAULT_GRID_COLOR = Color.rgb(222, 248, 255);
 
     // Not currently configurable.
     private final boolean northBoundActive = true;
@@ -54,10 +56,10 @@ public class GraphEditorProperties {
     private double westBoundValue = DEFAULT_BOUND_VALUE;
 
     // Off by default.
-    private final BooleanProperty gridVisibleProperty = new SimpleBooleanProperty();
-    private final BooleanProperty snapToGridProperty = new SimpleBooleanProperty();
-    private final DoubleProperty gridSpacingProperty = new SimpleDoubleProperty(DEFAULT_GRID_SPACING);
-    private final ObjectProperty<Color> gridColorProperty = new SimpleObjectProperty<>();
+    private final BooleanProperty gridVisibleProperty = new SimpleBooleanProperty(this, "gridVisible");
+    private final BooleanProperty snapToGridProperty = new SimpleBooleanProperty(this, "snapToGrid");
+    private final DoubleProperty gridSpacingProperty = new SimpleDoubleProperty(this, "gridSpacing", DEFAULT_GRID_SPACING);
+    private final ObjectProperty<Paint> gridColorProperty = new SimpleObjectProperty<>(this, "gridColor", DEFAULT_GRID_COLOR);
 
     private final Map<String, String> customProperties = new HashMap<>();
 
@@ -308,7 +310,7 @@ public class GraphEditorProperties {
      * 
      * @return the grid color, or null if nothing was set
      */
-    public Color getGridColor() {
+    public Paint getGridColor() {
         return gridColorProperty.get();
     }
 
@@ -317,7 +319,7 @@ public class GraphEditorProperties {
      * 
      * @param gridColor the new grid {@link Color}
      */
-    public void setGridColor(final Color gridColor) {
+    public void setGridColor(final Paint gridColor) {
         gridColorProperty.set(gridColor);
     }
 
@@ -326,7 +328,7 @@ public class GraphEditorProperties {
      * 
      * @return the grid color {@link ObjectProperty}
      */
-    public ObjectProperty<Color> gridColorProperty() {
+    public ObjectProperty<Paint> gridColorProperty() {
         return gridColorProperty;
     }
 

--- a/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorGrid.java
+++ b/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorGrid.java
@@ -3,30 +3,90 @@
  */
 package de.tesis.dynaware.grapheditor.core.view;
 
-import javafx.scene.Group;
-import javafx.scene.paint.Color;
-import javafx.scene.shape.Line;
+import com.sun.javafx.css.converters.PaintConverter;
+import com.sun.javafx.css.converters.SizeConverter;
 import de.tesis.dynaware.grapheditor.core.DefaultGraphEditor;
 import de.tesis.dynaware.grapheditor.utils.GraphEditorProperties;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Paint;
 
 /**
  * The alignment grid that appears in the background of the editor.
  */
-public class GraphEditorGrid extends Group {
+public class GraphEditorGrid extends Pane {
 
     // This is to make the stroke be drawn 'on pixel'.
     private static final double HALF_PIXEL_OFFSET = -0.5;
-    private static final Color DEFAULT_GRID_COLOR = Color.rgb(222, 248, 255);
+    private static final String GRID_STYLE_CLASS = "graph-grid";
 
     private GraphEditorProperties editorProperties;
+    private final Canvas canvas = new Canvas();
+    private boolean needsLayout = false;
+    
+    private final StyleableObjectProperty<Paint> gridColor = new StyleableObjectProperty<Paint>(GraphEditorProperties.DEFAULT_GRID_COLOR) {
+
+        @Override
+        public CssMetaData<? extends Styleable, Paint> getCssMetaData() {
+            return StyleableProperties.GRID_COLOR;
+        }
+
+        @Override
+        public Object getBean() {
+            return GraphEditorGrid.this;
+        }
+
+        @Override
+        public String getName() {
+            return "gridColor";
+        }
+
+        @Override
+        protected void invalidated() {
+            needsLayout = true;
+            requestLayout();
+        }
+    };
+		
+    private final StyleableObjectProperty<Number> gridSpacing = new StyleableObjectProperty<Number>(GraphEditorProperties.DEFAULT_GRID_SPACING) {
+
+        @Override
+        public CssMetaData<? extends Styleable, Number> getCssMetaData() {
+            return StyleableProperties.GRID_SPACING;
+        }
+
+        @Override
+        public Object getBean() {
+            return GraphEditorGrid.this;
+        }
+
+        @Override
+        public String getName() {
+            return "gridSpacing";
+        }
+
+        @Override
+        protected void invalidated() {
+            needsLayout = true;
+            requestLayout();
+        }
+    };
 
     /**
-     * Creates a new grid manager. Only one instance should exist per {@link DefaultGraphEditor} instance.
+     * Creates a new grid manager. Only one instance should exist per
+     * {@link DefaultGraphEditor} instance.
      */
     public GraphEditorGrid() {
-
-        // The grid should under NO circumstances interfere with (a) the layout of its parent, or (b) mouse events.
-        setManaged(false);
+        getStyleClass().add(GRID_STYLE_CLASS);
+        getChildren().add(canvas);
         setMouseTransparent(true);
     }
 
@@ -36,55 +96,113 @@ public class GraphEditorGrid extends Group {
      * @param editorProperties a {@link GraphEditorProperties} instance
      */
     public void setProperties(final GraphEditorProperties editorProperties) {
+        // remove binding to old properties:
+        if (this.editorProperties != null) {
+            gridColor.unbindBidirectional(this.editorProperties.gridColorProperty());
+            gridSpacing.unbindBidirectional(this.editorProperties.gridSpacingProperty());
+        }
+
         this.editorProperties = editorProperties;
+        
+        // bind to properties: (do not use bind() because the property will then not be settable via CSS)
+        if (this.editorProperties != null) {
+            gridColor.bindBidirectional(this.editorProperties.gridColorProperty());
+            gridSpacing.bindBidirectional(this.editorProperties.gridSpacingProperty());
+        }
+    }
+    
+    
+    
+    @Override
+    protected void layoutChildren() {
+        final int top = (int) snappedTopInset();
+        final int right = (int) snappedRightInset();
+        final int bottom = (int) snappedBottomInset();
+        final int left = (int) snappedLeftInset();
+        final int width = (int) getWidth() - left - right;
+        final int height = (int) getHeight() - top - bottom;
+        final double spacing = gridSpacing.get().doubleValue();
+
+        canvas.setLayoutX(left);
+        canvas.setLayoutY(top);
+
+        if (width != canvas.getWidth() || height != canvas.getHeight() || needsLayout) {
+            canvas.setWidth(width);
+            canvas.setHeight(height);
+
+            GraphicsContext g = canvas.getGraphicsContext2D();
+            g.clearRect(0, 0, width, height);
+            g.setStroke(gridColor.get());
+
+            final int hLineCount = (int) Math.floor((height + 1) / spacing);
+            final int vLineCount = (int) Math.floor((width + 1) / spacing);
+
+            for (int i = 0; i < hLineCount; i++) {
+                g.strokeLine(0, snap((i + 1) * spacing), width, snap((i + 1) * spacing));
+            }
+
+            for (int i = 0; i < vLineCount; i++) {
+                g.strokeLine(snap((i + 1) * spacing), 0, snap((i + 1) * spacing), height);
+            }
+
+            needsLayout = false;
+        }
     }
 
+    private static double snap(double y) {
+        return ((int) y) + HALF_PIXEL_OFFSET;
+    }
+    
     /**
-     * Draws the grid for the given width and height.
-     *
-     * @param width the width of the editor region
-     * @param height the height of the editor region
+     * @return The CssMetaData associated with this class, including the
+     * CssMetaData of its super classes.
      */
-    public void draw(final double width, final double height) {
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return StyleableProperties.STYLEABLES;
+    }
 
-        final double spacing = editorProperties.getGridSpacing();
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return getClassCssMetaData();
+    }
 
-        getChildren().clear();
+    private static class StyleableProperties {
 
-        final int hLineCount = (int) Math.floor((height + 1) / spacing);
-        final int vLineCount = (int) Math.floor((width + 1) / spacing);
+        private static final CssMetaData<GraphEditorGrid, Paint> GRID_COLOR = new CssMetaData<GraphEditorGrid, Paint>(
+            "-graph-grid-color", PaintConverter.getInstance()) {
 
-        final Color gridColor;
-        if (editorProperties.getGridColor() != null) {
-            gridColor = editorProperties.getGridColor();
-        } else {
-            gridColor = DEFAULT_GRID_COLOR;
-        }
+            @Override
+            public boolean isSettable(GraphEditorGrid node) {
+                return !node.gridColor.isBound();
+            }
 
-        for (int i = 0; i < hLineCount; i++) {
+            @Override
+            public StyleableProperty<Paint> getStyleableProperty(GraphEditorGrid node) {
+                return node.gridColor;
+            }
+        };
 
-            final Line hLine = new Line();
+        private static final CssMetaData<GraphEditorGrid, Number> GRID_SPACING = new CssMetaData<GraphEditorGrid, Number>(
+            "-graph-grid-spacing", SizeConverter.getInstance()) {
 
-            hLine.setStartX(0);
-            hLine.setEndX(width);
-            hLine.setStartY((i + 1) * spacing + HALF_PIXEL_OFFSET);
-            hLine.setEndY((i + 1) * spacing + HALF_PIXEL_OFFSET);
-            hLine.setStroke(gridColor);
+            @Override
+            public boolean isSettable(GraphEditorGrid node) {
+                return !node.gridSpacing.isBound();
+            }
 
-            getChildren().add(hLine);
-        }
+            @Override
+            public StyleableProperty<Number> getStyleableProperty(GraphEditorGrid node) {
+                return node.gridSpacing;
+            }
+        };
 
-        for (int i = 0; i < vLineCount; i++) {
-
-            final Line vLine = new Line();
-
-            vLine.setStartX((i + 1) * spacing + HALF_PIXEL_OFFSET);
-            vLine.setEndX((i + 1) * spacing + HALF_PIXEL_OFFSET);
-            vLine.setStartY(0);
-            vLine.setEndY(height);
-            vLine.setStroke(gridColor);
-
-            getChildren().add(vLine);
+        private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
+        static {
+            final List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(Pane.getClassCssMetaData());
+            styleables.add(GRID_COLOR);
+            styleables.add(GRID_SPACING);
+            STYLEABLES = Collections.unmodifiableList(styleables);
         }
     }
+    
 }

--- a/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorView.java
+++ b/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorView.java
@@ -59,18 +59,14 @@ public class GraphEditorView extends Region {
      */
     public GraphEditorView() {
 
-        getStylesheets().add(GraphEditorView.class.getResource(STYLESHEET_VIEW).toExternalForm());
-        getStylesheets().add(GraphEditorView.class.getResource(STYLESHEET_DEFAULTS).toExternalForm());
-
+        getStylesheets().addAll(GraphEditorView.class.getResource(STYLESHEET_VIEW).toExternalForm(),
+                GraphEditorView.class.getResource(STYLESHEET_DEFAULTS).toExternalForm());
         getStyleClass().addAll(STYLE_CLASS);
 
         setMaxWidth(GraphEditorProperties.DEFAULT_MAX_WIDTH);
         setMaxHeight(GraphEditorProperties.DEFAULT_MAX_HEIGHT);
 
         initializeLayers();
-        initializeGrid();
-
-        getChildren().add(selectionBox);
     }
 
     /**
@@ -172,15 +168,13 @@ public class GraphEditorView extends Region {
      * @param editorProperties the {@link GraphEditorProperties} instance to be used by the view
      */
     public void setEditorProperties(final GraphEditorProperties editorProperties) {
-
         this.editorProperties = editorProperties;
-
         grid.setProperties(editorProperties);
-        grid.setVisible(editorProperties.isGridVisible());
-
-        editorProperties.gridVisibleProperty().addListener((v, o, n) -> grid.setVisible(n));
-        editorProperties.gridSpacingProperty().addListener((v, o, n) -> grid.draw(getWidth(), getHeight()));
-        editorProperties.gridColorProperty().addListener((v, o, n) -> grid.draw(getWidth(), getHeight()));
+        if (editorProperties != null) {
+            grid.visibleProperty().bind(editorProperties.gridVisibleProperty());
+        } else {
+            grid.visibleProperty().unbind();
+        }
     }
 
     /**
@@ -230,6 +224,7 @@ public class GraphEditorView extends Region {
     protected void layoutChildren() {
         nodeLayer.resizeRelocate(0, 0, getWidth(), getHeight());
         connectionLayer.resizeRelocate(0, 0, getWidth(), getHeight());
+        grid.resizeRelocate(0, 0, getWidth(), getHeight());
     }
 
     /**
@@ -260,20 +255,8 @@ public class GraphEditorView extends Region {
         connectionLayer.minHeightProperty().bind(minHeightProperty());
 
         // Node layer should be on top of connection layer, so we add it second.
-        getChildren().add(connectionLayer);
-        getChildren().add(nodeLayer);
-    }
-
-    /**
-     * Adds a listener to the width and height properties of the view to tell the grid to redraw.
-     */
-    private void initializeGrid() {
-
-        getChildren().add(grid);
-        grid.toBack();
-
-        widthProperty().addListener((v, o, n) -> grid.draw(getWidth(), getHeight()));
-        heightProperty().addListener((v, o, n) -> grid.draw(getWidth(), getHeight()));
+        // Grid layer is on the lowest level so we add it at first
+        getChildren().addAll(grid, connectionLayer, nodeLayer, selectionBox);
     }
 
     /**


### PR DESCRIPTION
As discucces here: https://github.com/tesis-dynaware/graph-editor/issues/1
I created an intial pull request to add two new styleable properties for the grid spacing and the grid color and replaced the collection of individual lines as nodes with a single canvas element.

The zoomed-in canvas will look blurry. But I think that is another topic which we should fix seperately as the current way of zooming in is not perfect either (the grid lines will get thicker as the whole scene graph is scaled up).
