### PR TITLE
Moved Grid stroke-color to GraphEditorGrid with styleable property.

### DIFF
--- a/api/src/main/java/de/tesis/dynaware/grapheditor/utils/GraphEditorProperties.java
+++ b/api/src/main/java/de/tesis/dynaware/grapheditor/utils/GraphEditorProperties.java
@@ -8,11 +8,8 @@ import java.util.Map;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.scene.paint.Color;
 
 /**
  * General properties for the graph editor.
@@ -54,10 +51,9 @@ public class GraphEditorProperties {
     private double westBoundValue = DEFAULT_BOUND_VALUE;
 
     // Off by default.
-    private final BooleanProperty gridVisibleProperty = new SimpleBooleanProperty();
-    private final BooleanProperty snapToGridProperty = new SimpleBooleanProperty();
-    private final DoubleProperty gridSpacingProperty = new SimpleDoubleProperty(DEFAULT_GRID_SPACING);
-    private final ObjectProperty<Color> gridColorProperty = new SimpleObjectProperty<>();
+    private final BooleanProperty gridVisibleProperty = new SimpleBooleanProperty(this, "gridVisible");
+    private final BooleanProperty snapToGridProperty = new SimpleBooleanProperty(this, "snapToGrid");
+    private final DoubleProperty gridSpacingProperty = new SimpleDoubleProperty(this, "gridSpacing", DEFAULT_GRID_SPACING);
 
     private final Map<String, String> customProperties = new HashMap<>();
 
@@ -89,7 +85,6 @@ public class GraphEditorProperties {
         gridVisibleProperty.set(editorProperties.isGridVisible());
         snapToGridProperty.set(editorProperties.isSnapToGridOn());
         gridSpacingProperty.set(editorProperties.getGridSpacing());
-        gridColorProperty.set(editorProperties.getGridColor());
     }
 
     /**
@@ -301,33 +296,6 @@ public class GraphEditorProperties {
      */
     public DoubleProperty gridSpacingProperty() {
         return gridSpacingProperty;
-    }
-
-    /**
-     * Gets the grid color.
-     * 
-     * @return the grid color, or null if nothing was set
-     */
-    public Color getGridColor() {
-        return gridColorProperty.get();
-    }
-
-    /**
-     * Sets the new grid color.
-     * 
-     * @param gridColor the new grid {@link Color}
-     */
-    public void setGridColor(final Color gridColor) {
-        gridColorProperty.set(gridColor);
-    }
-
-    /**
-     * Gets the grid color property.
-     * 
-     * @return the grid color {@link ObjectProperty}
-     */
-    public ObjectProperty<Color> gridColorProperty() {
-        return gridColorProperty;
     }
 
     /**

--- a/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorGrid.java
+++ b/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorGrid.java
@@ -3,23 +3,57 @@
  */
 package de.tesis.dynaware.grapheditor.core.view;
 
+import com.sun.javafx.css.converters.PaintConverter;
 import javafx.scene.Group;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
 import de.tesis.dynaware.grapheditor.core.DefaultGraphEditor;
 import de.tesis.dynaware.grapheditor.utils.GraphEditorProperties;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.scene.paint.Paint;
 
 /**
  * The alignment grid that appears in the background of the editor.
  */
 public class GraphEditorGrid extends Group {
 
+    private static final String GRID_STYLE_CLASS = "graph-grid";
+    
     // This is to make the stroke be drawn 'on pixel'.
     private static final double HALF_PIXEL_OFFSET = -0.5;
+    
     private static final Color DEFAULT_GRID_COLOR = Color.rgb(222, 248, 255);
 
     private GraphEditorProperties editorProperties;
 
+    private final StyleableObjectProperty<Paint> gridColor = new StyleableObjectProperty<Paint>(DEFAULT_GRID_COLOR) {
+
+        @Override
+        public CssMetaData<? extends Styleable, Paint> getCssMetaData() {
+            return StyleableProperties.GRID_COLOR;
+        }
+
+        @Override
+        public Object getBean() {
+            return GraphEditorGrid.this;
+        }
+
+        @Override
+        public String getName() {
+            return "gridColor";
+        }
+
+        @Override
+        protected void invalidated() {
+        }
+    };
+    
     /**
      * Creates a new grid manager. Only one instance should exist per {@link DefaultGraphEditor} instance.
      */
@@ -28,6 +62,7 @@ public class GraphEditorGrid extends Group {
         // The grid should under NO circumstances interfere with (a) the layout of its parent, or (b) mouse events.
         setManaged(false);
         setMouseTransparent(true);
+        getStyleClass().add(GRID_STYLE_CLASS);
     }
 
     /**
@@ -54,13 +89,6 @@ public class GraphEditorGrid extends Group {
         final int hLineCount = (int) Math.floor((height + 1) / spacing);
         final int vLineCount = (int) Math.floor((width + 1) / spacing);
 
-        final Color gridColor;
-        if (editorProperties.getGridColor() != null) {
-            gridColor = editorProperties.getGridColor();
-        } else {
-            gridColor = DEFAULT_GRID_COLOR;
-        }
-
         for (int i = 0; i < hLineCount; i++) {
 
             final Line hLine = new Line();
@@ -69,7 +97,7 @@ public class GraphEditorGrid extends Group {
             hLine.setEndX(width);
             hLine.setStartY((i + 1) * spacing + HALF_PIXEL_OFFSET);
             hLine.setEndY((i + 1) * spacing + HALF_PIXEL_OFFSET);
-            hLine.setStroke(gridColor);
+            hLine.strokeProperty().bind(gridColor);
 
             getChildren().add(hLine);
         }
@@ -82,9 +110,46 @@ public class GraphEditorGrid extends Group {
             vLine.setEndX((i + 1) * spacing + HALF_PIXEL_OFFSET);
             vLine.setStartY(0);
             vLine.setEndY(height);
-            vLine.setStroke(gridColor);
+            vLine.strokeProperty().bind(gridColor);
 
             getChildren().add(vLine);
+        }
+    }
+    
+    /**
+     * @return The CssMetaData associated with this class, including the
+     * CssMetaData of its super classes.
+     */
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return StyleableProperties.STYLEABLES;
+    }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return getClassCssMetaData();
+    }
+
+    private static class StyleableProperties {
+
+        private static final CssMetaData<GraphEditorGrid, Paint> GRID_COLOR = new CssMetaData<GraphEditorGrid, Paint>(
+            "-graph-grid-color", PaintConverter.getInstance()) {
+
+            @Override
+            public boolean isSettable(GraphEditorGrid node) {
+                return !node.gridColor.isBound();
+            }
+
+            @Override
+            public StyleableProperty<Paint> getStyleableProperty(GraphEditorGrid node) {
+                return node.gridColor;
+            }
+        };
+
+        private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
+        static {
+            final List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(Group.getClassCssMetaData());
+            styleables.add(GRID_COLOR);
+            STYLEABLES = Collections.unmodifiableList(styleables);
         }
     }
 }

--- a/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorView.java
+++ b/core/src/main/java/de/tesis/dynaware/grapheditor/core/view/GraphEditorView.java
@@ -180,7 +180,6 @@ public class GraphEditorView extends Region {
 
         editorProperties.gridVisibleProperty().addListener((v, o, n) -> grid.setVisible(n));
         editorProperties.gridSpacingProperty().addListener((v, o, n) -> grid.draw(getWidth(), getHeight()));
-        editorProperties.gridColorProperty().addListener((v, o, n) -> grid.draw(getWidth(), getHeight()));
     }
 
     /**


### PR DESCRIPTION
I left the grid spacing out of the refactoring on purpose because currently it is strongly tied to the GraphEditorProperties.
I tested the CSS styleable property with a single GraphEditor view and a GraphEditorContainer.
